### PR TITLE
Make date handling more strict

### DIFF
--- a/hashcash.py
+++ b/hashcash.py
@@ -121,13 +121,14 @@ def hashcash_mint(resource, nbits=None, stime=None):
         date_time = datetime.datetime.today().strftime('%y%m%d%H%M%S')
     else:
         # Valid date formats are: YYMMDD, YYMMDDhhmm, YYMMDDhhmmss
-        try:
+        if len(stime) == 12:
             datetime.datetime.strptime(stime, '%y%m%d%H%M%S')
-        except ValueError:
-            try:
-                datetime.datetime.strptime(stime, '%y%m%d%H%M')
-            except ValueError:
-                datetime.datetime.strptime(stime, '%y%m%d')
+        elif len(stime) == 10:
+            datetime.datetime.strptime(stime, '%y%m%d%H%M')
+        elif len(stime) == 6:
+            datetime.datetime.strptime(stime, '%y%m%d')
+        else:
+            raise ValueError
         date_time = stime
 
     # Stamp format is ver:bits:date:resource:[ext]:rand:counter
@@ -287,13 +288,14 @@ def _parse_time_stamp(time_stamp):
     """
 
     # Valid date formats are: YYMMDD, YYMMDDhhmm, YYMMDDhhmmss
-    try:
+    if len(time_stamp) == 12:
         epoch_time = time.mktime(time.strptime(time_stamp, '%y%m%d%H%M%S'))
-    except ValueError:
-        try:
-            epoch_time = time.mktime(time.strptime(time_stamp, '%y%m%d%H%M'))
-        except ValueError:
-            epoch_time = time.mktime(time.strptime(time_stamp, '%y%m%d'))
+    elif len(time_stamp) == 10:
+        epoch_time = time.mktime(time.strptime(time_stamp, '%y%m%d%H%M'))
+    elif len(time_stamp) == 6:
+        epoch_time = time.mktime(time.strptime(time_stamp, '%y%m%d'))
+    else:
+        raise ValueError
 
     return epoch_time
 


### PR DESCRIPTION
Chained attempts at parsing datestamps isn't appropriate in this instance as a non-bug in underlying strptime() behaviour means that 2 digit months (`%m`) can get away with only consuming one.

This means that "YYMMDD" dates like 201231 hit the YYMMDDhhmm path first and are parsed incorrectly as 20/1/2 3:1, as in 2nd Jan 20 at 0301 in the morning, ~12 months off.

Selecting the parse format by length makes the parsing more strict and helps prevent this.

```python
import time

mytime = time.mktime(
	time.strptime("201231", "%y%m%d%H%M")
	# should be 20/12/31
)

print(time.strftime("%y/%m/%d %H:%M", time.gmtime(mytime)))
# 20/01/02 03:01
```